### PR TITLE
Allow opening SOFA from memory

### DIFF
--- a/libmysofa-sys/Cargo.toml
+++ b/libmysofa-sys/Cargo.toml
@@ -20,7 +20,7 @@ cc = "1.0.101"
 system-deps = "7.0"
 
 [package.metadata.system-deps]
-libmysofa = "1"
+libmysofa = "1.3"
 
 [package.metadata.cargo-machete]
 ignored = ["libz-sys"]

--- a/libmysofa-sys/src/lib.rs
+++ b/libmysofa-sys/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use std::os::raw::{c_char, c_int, c_short, c_uint, c_ulong, c_void};
+use std::os::raw::{c_char, c_int, c_long, c_short, c_uint, c_ulong, c_void};
 
 pub const MYSOFA_DEFAULT_NEIGH_STEP_ANGLE: f64 = 0.5;
 pub const MYSOFA_DEFAULT_NEIGH_STEP_RADIUS: f64 = 0.01;
@@ -165,6 +165,33 @@ extern "C" {
 
     pub fn mysofa_open_advanced(
         filename: *const c_char,
+        samplerate: f32,
+        filterlength: *mut c_int,
+        err: *mut c_int,
+        norm: bool,
+        neighbor_angle_step: f32,
+        neighbor_radius_step: f32,
+    ) -> *mut MYSOFA_EASY;
+
+    pub fn mysofa_open_data(
+        data: *const c_char,
+        size: c_long,
+        samplerate: f32,
+        filterlength: *mut c_int,
+        err: *mut c_int,
+    ) -> *mut MYSOFA_EASY;
+
+    pub fn mysofa_open_data_no_norm(
+        data: *const c_char,
+        size: c_long,
+        samplerate: f32,
+        filterlength: *mut c_int,
+        err: *mut c_int,
+    ) -> *mut MYSOFA_EASY;
+
+    pub fn mysofa_open_data_advanced(
+        data: *const c_char,
+        size: c_long,
         samplerate: f32,
         filterlength: *mut c_int,
         err: *mut c_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,4 +68,17 @@ mod tests {
         let mut filter = Filter::new(filt_len);
         sofa.filter(0.0, 1.0, 0.0, &mut filter);
     }
+
+    #[test]
+    fn open_data_test() {
+        let cwd = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        std::env::set_current_dir(cwd).unwrap();
+
+        let data = std::fs::read("libmysofa-sys/libmysofa/tests/tester.sofa").unwrap();
+        let sofa = Sofar::open_data(&data).unwrap();
+        let filt_len = sofa.filter_len();
+
+        let mut filter = Filter::new(filt_len);
+        sofa.filter(0.0, 1.0, 0.0, &mut filter);
+    }
 }


### PR DESCRIPTION
The patch adds an interface for opening sofa from memory.